### PR TITLE
Restrict CI compiler combinations.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,9 +22,9 @@ jobs:
         c-compiler: [gcc-10, clang]
         cxx-compiler: [g++-10, clang++]
         cmake-build-type: [DEBUG, RELEASE]
-        include:
-          - { c-compiler: gcc-10, cxx-compiler: g++10, cmake-build-type: ..., os: ... }
-          - { c-compiler: clang, cxx-compiler: clang++, cmake-build-type: ..., os: ... }
+        exclude:
+          - { c-compiler: clang, cxx-compiler: g++-10 }
+          - { c-compiler: gcc-10, cxx-compiler: clang++ }
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,9 @@ jobs:
         c-compiler: [gcc-10, clang]
         cxx-compiler: [g++-10, clang++]
         cmake-build-type: [DEBUG, RELEASE]
+        include:
+          - { c-compiler: gcc-10, cxx-compiler: g++10 }
+          - { c-compiler: clang, cxx-compiler: clang++ }
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,8 +23,8 @@ jobs:
         cxx-compiler: [g++-10, clang++]
         cmake-build-type: [DEBUG, RELEASE]
         include:
-          - { c-compiler: gcc-10, cxx-compiler: g++10, ... }
-          - { c-compiler: clang, cxx-compiler: clang++, ... }
+          - { c-compiler: gcc-10, cxx-compiler: g++10, cmake-build-type: ..., os: ... }
+          - { c-compiler: clang, cxx-compiler: clang++, cmake-build-type: ..., os: ... }
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,8 +23,8 @@ jobs:
         cxx-compiler: [g++-10, clang++]
         cmake-build-type: [DEBUG, RELEASE]
         include:
-          - { c-compiler: gcc-10, cxx-compiler: g++10 }
-          - { c-compiler: clang, cxx-compiler: clang++ }
+          - { c-compiler: gcc-10, cxx-compiler: g++10, ... }
+          - { c-compiler: clang, cxx-compiler: clang++, ... }
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
We don't need to test clang with g++ and vice versa: more common use cases are enough.