### PR TITLE
Changed format_string to use Spans where possible.

### DIFF
--- a/swimps-container/include/swimps-container.h
+++ b/swimps-container/include/swimps-container.h
@@ -20,7 +20,7 @@ namespace swimps::container {
         //! \tparam  N  The size of the buffer (intended to be inferred).
         //!
         template <size_t N>
-        explicit constexpr Span(T (&buffer)[N]) noexcept
+        constexpr Span(T (&buffer)[N]) noexcept
             : Span(&buffer[0], N) { }
 
         //!
@@ -148,6 +148,7 @@ namespace swimps::container {
         //! \returns  The modified span with the offset increased by the requested amount.
         //!
         constexpr Span& operator+= (const size_t offset) noexcept {
+            // Make sure remaining elements isn't going to go below 0.
             assert(m_remainingElements >= offset);
             m_remainingElements -= offset;
             m_bufferCurrent += offset;
@@ -196,7 +197,9 @@ namespace swimps::container {
         //!
         //! \returns  The number of elements left in the span.
         //!
-        constexpr size_t remaining_size() const noexcept {
+        //! \note  This includes the current element.
+        //!
+        constexpr size_t current_size() const noexcept {
             return m_remainingElements;
         }
 
@@ -240,7 +243,7 @@ namespace swimps::container {
     constexpr bool operator== (const Span<T>& lhs, const Span<T>& rhs) noexcept {
         return &lhs[0] == &rhs[0]
             && lhs.original_size() == rhs.original_size()
-            && lhs.remaining_size() == rhs.remaining_size();
+            && lhs.current_size() == rhs.current_size();
     }
 
     //!

--- a/swimps-io/CMakeLists.txt
+++ b/swimps-io/CMakeLists.txt
@@ -3,4 +3,4 @@ project(swimps-io VERSION 0.0.1 LANGUAGES CXX)
 
 add_library(swimps-io SHARED source/swimps-io.cpp)
 target_include_directories(swimps-io PUBLIC include)
-target_link_libraries(swimps-io m)
+target_link_libraries(swimps-io swimps-container m)

--- a/swimps-io/include/swimps-io.h
+++ b/swimps-io/include/swimps-io.h
@@ -3,6 +3,8 @@
 #include <cstdarg>
 #include <cstddef>
 
+#include "swimps-container.h"
+
 namespace swimps::io {
 
     //!
@@ -51,7 +53,6 @@ namespace swimps::io {
     //! \param[in]   formatBuffer      The buffer containing the format string. Does not need to be null terminated.
     //! \param[in]   formatBufferSize  The size of the format buffer, in bytes.
     //! \param[out]  targetBuffer      Where to write the formatted string.
-    //! \param[in]   targetBufferSize  The size of the target buffer, in bytes.
     //! \param[in]   ...               The values to use when formatting the string.
     //!
     //! \returns  The number of bytes written to the target buffer.
@@ -71,8 +72,7 @@ namespace swimps::io {
     //!
     size_t format_string(const char* __restrict__ formatbuffer,
                          size_t formatbuffersize,
-                         char* __restrict__ targetbuffer,
-                         size_t targetbuffersize,
+                         swimps::container::Span<char> targetbuffer,
                          ...);
 
     //!
@@ -82,7 +82,6 @@ namespace swimps::io {
     //!
     size_t format_string_valist(const char* __restrict__ formatbuffer,
                                 size_t formatbuffersize,
-                                char* __restrict__ targetbuffer,
-                                size_t targetbuffersize,
+                                swimps::container::Span<char> targetbuffer,
                                 va_list varargs);
 }

--- a/swimps-log/include/swimps-log.h
+++ b/swimps-log/include/swimps-log.h
@@ -95,7 +95,6 @@ namespace swimps::log {
             formatBuffer,
             formatBufferSize,
             targetBuffer,
-            targetBufferSize,
             varargs
         );
 

--- a/swimps-profile/source/swimps-profile-parent.cpp
+++ b/swimps-profile/source/swimps-profile-parent.cpp
@@ -43,7 +43,6 @@ swimps::error::ErrorCode swimps_profile_parent(const pid_t childPid) {
                 const size_t bytesWritten = swimps::io::format_string(formatBuffer,
                                                                  strlen(formatBuffer),
                                                                  targetBuffer,
-                                                                 sizeof targetBuffer,
                                                                  signalNumber,
                                                                  strsignal(signalNumber));
 
@@ -69,7 +68,6 @@ swimps::error::ErrorCode swimps_profile_parent(const pid_t childPid) {
                 const size_t bytesWritten = swimps::io::format_string(formatBuffer,
                                                                  strlen(formatBuffer),
                                                                  targetBuffer,
-                                                                 sizeof targetBuffer,
                                                                  errno,
                                                                  strerror(errno));
 

--- a/swimps-test/unit/swimps-container-unit-test/source/span-test.cpp
+++ b/swimps-test/unit/swimps-container-unit-test/source/span-test.cpp
@@ -18,7 +18,7 @@ SCENARIO("swimps::container::span", "[swimps-container]") {
             }
 
             THEN("The remaining size of the span is 5") {
-                REQUIRE(span.remaining_size() == 5);
+                REQUIRE(span.current_size() == 5);
             }
 
             THEN("The target buffer is unchanged.") {
@@ -64,7 +64,7 @@ SCENARIO("swimps::container::span", "[swimps-container]") {
                         const auto returnedSpan = span++;
 
                         THEN("The returned value hasn't changed; this is *post* increment.") {
-                            REQUIRE(returnedSpan.remaining_size() == 5);
+                            REQUIRE(returnedSpan.current_size() == 5);
                             REQUIRE(returnedSpan[0] == 42);
                             REQUIRE(returnedSpan[1] == 17);
                             REQUIRE(returnedSpan[2] == 50);
@@ -74,7 +74,7 @@ SCENARIO("swimps::container::span", "[swimps-container]") {
                     }
 
                     THEN("The remaining size of the original span goes down by 1.") {
-                        REQUIRE(span.remaining_size() == 4);
+                        REQUIRE(span.current_size() == 4);
                     }
 
                     THEN("The span now reads at an offset of 2.") {
@@ -104,7 +104,7 @@ SCENARIO("swimps::container::span", "[swimps-container]") {
                         }
 
                         THEN("The remaining size of the original span goes down by 1.") {
-                            REQUIRE(span.remaining_size() == 3);
+                            REQUIRE(span.current_size() == 3);
                         }
 
                         AND_WHEN("Each valid index is written to.") {
@@ -136,7 +136,7 @@ SCENARIO("swimps::container::span", "[swimps-container]") {
                                     const auto returnedSpan = span--;
 
                                     THEN("The return value hasn't changed; this is *post* decrement.") {
-                                        REQUIRE(returnedSpan.remaining_size() == 3);
+                                        REQUIRE(returnedSpan.current_size() == 3);
                                         REQUIRE(returnedSpan[0] == 81);
                                         REQUIRE(returnedSpan[1] == 82);
                                         REQUIRE(returnedSpan[2] == 83);
@@ -144,7 +144,7 @@ SCENARIO("swimps::container::span", "[swimps-container]") {
                                 }
 
                                 THEN("The remaining size of the original span increases by 1.") {
-                                    REQUIRE(span.remaining_size() == 4);
+                                    REQUIRE(span.current_size() == 4);
                                 }
 
                                 THEN("The target buffer is unchanged.") {
@@ -175,7 +175,7 @@ SCENARIO("swimps::container::span", "[swimps-container]") {
                                     }
 
                                     THEN("The remaining size of the original span increases by 1.") {
-                                        REQUIRE(span.remaining_size() == 5);
+                                        REQUIRE(span.current_size() == 5);
                                     }
 
                                     THEN("The span reads at an offset of 1.") {
@@ -265,7 +265,7 @@ SCENARIO("swimps::container::span", "[swimps-container]") {
                 }
 
                 THEN("The remaining size of the span is correct.") {
-                    REQUIRE(span.remaining_size() == 8);
+                    REQUIRE(span.current_size() == 8);
                 }
 
                 THEN("Each byte reads back correctly.") {
@@ -298,7 +298,7 @@ SCENARIO("swimps::container::span", "[swimps-container]") {
                         REQUIRE(span[5] == 5);
                         REQUIRE(span[6] == 6);
                         REQUIRE(span[7] == 7);
-                        REQUIRE(span.remaining_size() == 8);
+                        REQUIRE(span.current_size() == 8);
                         REQUIRE(span.original_size() == 8);
                     }
 
@@ -313,7 +313,7 @@ SCENARIO("swimps::container::span", "[swimps-container]") {
                     }
 
                     THEN("The remaining size of the added span is correct.") {
-                        REQUIRE(addedSpan.remaining_size() == 7);
+                        REQUIRE(addedSpan.current_size() == 7);
                     }
 
                     THEN("The original size of the added span is correct.") {
@@ -346,7 +346,7 @@ SCENARIO("swimps::container::span", "[swimps-container]") {
                             REQUIRE(span[5] == 5);
                             REQUIRE(span[6] == 6);
                             REQUIRE(span[7] == 7);
-                            REQUIRE(span.remaining_size() == 8);
+                            REQUIRE(span.current_size() == 8);
                             REQUIRE(span.original_size() == 8);
                         }
 
@@ -358,7 +358,7 @@ SCENARIO("swimps::container::span", "[swimps-container]") {
                             REQUIRE(addedSpan[4] == 5);
                             REQUIRE(addedSpan[5] == 6);
                             REQUIRE(addedSpan[6] == 7);
-                            REQUIRE(addedSpan.remaining_size() == 7);
+                            REQUIRE(addedSpan.current_size() == 7);
                             REQUIRE(addedSpan.original_size() == 8);
                         }
 
@@ -374,7 +374,7 @@ SCENARIO("swimps::container::span", "[swimps-container]") {
                         }
 
                         THEN("The remaining size of the subtracted span is correct.") {
-                            REQUIRE(subtractedSpan.remaining_size() == 8);
+                            REQUIRE(subtractedSpan.current_size() == 8);
                         }
 
                         THEN("The original size of the subtracted span is correct.") {
@@ -402,7 +402,7 @@ SCENARIO("swimps::container::span", "[swimps-container]") {
                         REQUIRE(span[5] == 5);
                         REQUIRE(span[6] == 6);
                         REQUIRE(span[7] == 7);
-                        REQUIRE(span.remaining_size() == 8);
+                        REQUIRE(span.current_size() == 8);
                         REQUIRE(span.original_size() == 8);
                     }
 
@@ -415,7 +415,7 @@ SCENARIO("swimps::container::span", "[swimps-container]") {
                     }
 
                     THEN("The remaining size of the added span is correct.") {
-                        REQUIRE(addedSpan.remaining_size() == 5);
+                        REQUIRE(addedSpan.current_size() == 5);
                     }
 
                     THEN("The original size of the added span is correct.") {
@@ -441,7 +441,7 @@ SCENARIO("swimps::container::span", "[swimps-container]") {
                             REQUIRE(span[5] == 5);
                             REQUIRE(span[6] == 6);
                             REQUIRE(span[7] == 7);
-                            REQUIRE(span.remaining_size() == 8);
+                            REQUIRE(span.current_size() == 8);
                             REQUIRE(span.original_size() == 8);
                         }
 
@@ -451,7 +451,7 @@ SCENARIO("swimps::container::span", "[swimps-container]") {
                             REQUIRE(addedSpan[2] == 5);
                             REQUIRE(addedSpan[3] == 6);
                             REQUIRE(addedSpan[4] == 7);
-                            REQUIRE(addedSpan.remaining_size() == 5);
+                            REQUIRE(addedSpan.current_size() == 5);
                             REQUIRE(addedSpan.original_size() == 8);
                         }
 
@@ -466,7 +466,7 @@ SCENARIO("swimps::container::span", "[swimps-container]") {
                         }
 
                         THEN("The remaining size of the subtracted span is correct.") {
-                            REQUIRE(subtractedSpan.remaining_size() == 7);
+                            REQUIRE(subtractedSpan.current_size() == 7);
                         }
 
                         THEN("The original size of the subtracted span is correct.") {
@@ -501,7 +501,7 @@ SCENARIO("swimps::container::span", "[swimps-container]") {
                         }
 
                         THEN("The remaining size is correct.") {
-                            REQUIRE(movingSpan.remaining_size() == 2);
+                            REQUIRE(movingSpan.current_size() == 2);
                         }
 
                         THEN("The original size is correct.") {
@@ -517,7 +517,7 @@ SCENARIO("swimps::container::span", "[swimps-container]") {
                             REQUIRE(span[5] == 5);
                             REQUIRE(span[6] == 6);
                             REQUIRE(span[7] == 7);
-                            REQUIRE(span.remaining_size() == 8);
+                            REQUIRE(span.current_size() == 8);
                             REQUIRE(span.original_size() == 8);
                         }
 
@@ -538,7 +538,7 @@ SCENARIO("swimps::container::span", "[swimps-container]") {
                             }
 
                             THEN("The remaining size is correct.") {
-                                REQUIRE(movingSpan.remaining_size() == 3);
+                                REQUIRE(movingSpan.current_size() == 3);
                             }
 
                             THEN("The original size is correct.") {
@@ -554,7 +554,7 @@ SCENARIO("swimps::container::span", "[swimps-container]") {
                                 REQUIRE(span[5] == 5);
                                 REQUIRE(span[6] == 6);
                                 REQUIRE(span[7] == 7);
-                                REQUIRE(span.remaining_size() == 8);
+                                REQUIRE(span.current_size() == 8);
                                 REQUIRE(span.original_size() == 8);
                             }
 

--- a/swimps-test/unit/swimps-io-unit-test/source/swimps-format-string-test.cpp
+++ b/swimps-test/unit/swimps-io-unit-test/source/swimps-format-string-test.cpp
@@ -11,8 +11,7 @@ SCENARIO("swimps::io::format_string", "[swimps-io]") {
             const char formatBuffer[] = { 'a', 'b', 'c', 'd' };
             const size_t bytesWritten = swimps::io::format_string(formatBuffer,
                                                              sizeof formatBuffer,
-                                                             targetBuffer,
-                                                             sizeof targetBuffer);
+                                                             targetBuffer);
 
             THEN("The function returns that it has written 4 bytes.") {
                 REQUIRE(bytesWritten == 4);
@@ -41,8 +40,7 @@ SCENARIO("swimps::io::format_string", "[swimps-io]") {
             const char formatBuffer[] = "1234567"; // 8th is null terminator
             const size_t bytesWritten = swimps::io::format_string(formatBuffer,
                                                              sizeof formatBuffer,
-                                                             targetBuffer,
-                                                             sizeof targetBuffer);
+                                                             targetBuffer);
 
             THEN("The function returns that it has written 8 bytes.") {
                 REQUIRE(bytesWritten == 8);
@@ -69,8 +67,7 @@ SCENARIO("swimps::io::format_string", "[swimps-io]") {
             const char formatBuffer[] = { '%', 'd' };
             const size_t bytesWritten = swimps::io::format_string(formatBuffer,
                                                              sizeof formatBuffer,
-                                                             targetBuffer,
-                                                             2,
+                                                             swimps::container::Span<char>(targetBuffer, 2),
                                                              7);
 
             THEN("The function returns that it has written 1 byte.") {
@@ -96,8 +93,7 @@ SCENARIO("swimps::io::format_string", "[swimps-io]") {
             const char formatBuffer[] = { '%', 'd' };
             const size_t bytesWritten = swimps::io::format_string(formatBuffer,
                                                             sizeof formatBuffer,
-                                                            targetBuffer,
-                                                            2,
+                                                            swimps::container::Span<char>(targetBuffer, 2),
                                                             -1);
 
             THEN("The function returns that it has written 2 bytes.") {
@@ -123,8 +119,7 @@ SCENARIO("swimps::io::format_string", "[swimps-io]") {
             const char formatBuffer[] = { '%', 'd' };
             const size_t bytesWritten = swimps::io::format_string(formatBuffer,
                                                             sizeof formatBuffer,
-                                                            targetBuffer,
-                                                            1,
+                                                            swimps::container::Span<char>(targetBuffer, 1),
                                                             -9);
 
             THEN("The function returns that it has written one byte.") {
@@ -149,8 +144,7 @@ SCENARIO("swimps::io::format_string", "[swimps-io]") {
             const char formatBuffer[] = { '%', 'd' };
             const size_t bytesWritten = swimps::io::format_string(formatBuffer,
                                                              sizeof formatBuffer,
-                                                             targetBuffer,
-                                                             2,
+                                                             swimps::container::Span<char>(targetBuffer, 2),
                                                              1234);
 
             THEN("The function returns that it has written 2 bytes.") {
@@ -177,8 +171,7 @@ SCENARIO("swimps::io::format_string", "[swimps-io]") {
             const char formatBuffer[] = { '%', 'd' };
             const size_t bytesWritten = swimps::io::format_string(formatBuffer,
                                                                 sizeof formatBuffer,
-                                                                targetBuffer,
-                                                                4,
+                                                                swimps::container::Span<char>(targetBuffer, 4),
                                                                 -1234);
 
             THEN("The function returns that it has written 4 bytes.") {
@@ -209,7 +202,6 @@ SCENARIO("swimps::io::format_string", "[swimps-io]") {
             const size_t bytesWritten = swimps::io::format_string(formatBuffer,
                                                              sizeof formatBuffer,
                                                              targetBuffer,
-                                                             sizeof targetBuffer,
                                                              "The quick fox jumps over the lazy brown dog.");
 
             THEN("The function returns that it has written 44 bytes.") {
@@ -274,7 +266,6 @@ SCENARIO("swimps::io::format_string", "[swimps-io]") {
             const size_t bytesWritten = swimps::io::format_string(formatBuffer,
                                                              sizeof formatBuffer,
                                                              targetBuffer,
-                                                             sizeof targetBuffer,
                                                              "Greetings",
                                                              "Dave",
                                                              30);
@@ -310,7 +301,6 @@ SCENARIO("swimps::io::format_string", "[swimps-io]") {
             const size_t bytesWritten = swimps::io::format_string(formatBuffer,
                                                              sizeof formatBuffer,
                                                              targetBuffer,
-                                                             sizeof targetBuffer,
                                                              errno);
 
             THEN("The number of bytes claimed to be written is as expected.") {

--- a/swimps-test/unit/swimps-io-unit-test/source/swimps-format-string-valist-test.cpp
+++ b/swimps-test/unit/swimps-io-unit-test/source/swimps-format-string-valist-test.cpp
@@ -30,7 +30,6 @@ SCENARIO("swimps::io::format_string_valist", "[swimps-io]") {
                         formatBuffer,
                         sizeof formatBuffer,
                         targetBuffer,
-                        sizeof targetBuffer,
                         varargs
                     );
                 },


### PR DESCRIPTION
Removed "explicit" from the Span constructor so it can act as a drop-in replacement for targetBuffer.
Renamed remaining_size to current_size in swimps::container::Span to make its meaning clearer.