### PR TITLE
Use spans in the swimps::io::write_to_file_descriptor.

### DIFF
--- a/swimps-io/include/swimps-io.h
+++ b/swimps-io/include/swimps-io.h
@@ -2,6 +2,7 @@
 
 #include <cstdarg>
 #include <cstddef>
+#include <concepts>
 
 #include "swimps-container.h"
 
@@ -30,17 +31,35 @@ namespace swimps::io {
     //!
     //! \brief  Writes the provided data to the file specified.
     //!
-    //! \param[in]  sourceBuffer      The data to be written to the file. Does not need to be null terminated.
-    //! \param[in]  sourceBufferSize  The number of bytes to read from the source buffer.
-    //! \param[in]  fileDescriptor    The file to write the data to.
+    //! \param[in]  source          The data to be written to the file. Does not need to be null terminated.
+    //! \param[in]  fileDescriptor  The file to write the data to.
     //!
     //! \returns  The number of bytes written to the file.
     //!
     //! \note  This function is async signal safe.
     //!
-    size_t write_to_file_descriptor(const char* sourceBuffer,
-                                    size_t sourceBufferSize,
-                                    int fileDescriptor);
+    size_t write_to_file_descriptor(
+        swimps::container::Span<const char> source,
+        int fileDescriptor);
+
+    //!
+    //! \brief  Provides a wrapper around write_to_file_descriptor that makes writing integral types easier.
+    //!
+    //! \tparam  T  An integral type to write.
+    //!
+    //! \see  write_to_file_descriptor
+    //!
+    template <typename T>
+        requires std::integral<T>
+    size_t write_to_file_descriptor(
+        const T source,
+        int fileDescriptor) {
+
+        return write_to_file_descriptor(
+            { reinterpret_cast<const char*>(&source), sizeof(T) },
+            fileDescriptor
+        );
+    }
 
     //!
     //! \brief  Formats the string, as per printf rules (see supported list), into the target buffer.

--- a/swimps-io/source/swimps-io.cpp
+++ b/swimps-io/source/swimps-io.cpp
@@ -17,16 +17,14 @@ size_t swimps::io::write_to_buffer(
     return bytesToWrite;
 }
 
-size_t swimps::io::write_to_file_descriptor(const char* sourceBuffer,
-                                       size_t sourceBufferSize,
-                                       int fileDescriptor) {
-
-    assert(sourceBuffer != NULL);
+size_t swimps::io::write_to_file_descriptor(
+    swimps::container::Span<const char> source,
+    int fileDescriptor) {
 
     size_t bytesWrittenTotal = 0;
 
-    while(sourceBufferSize > 0) {
-        const ssize_t bytesWritten = write(fileDescriptor, sourceBuffer, sourceBufferSize);
+    while(source.current_size() > 0) {
+        const ssize_t bytesWritten = write(fileDescriptor, &source[0], source.current_size());
 
         // i.e. if an error occured
         if (bytesWritten < 0) {
@@ -34,8 +32,7 @@ size_t swimps::io::write_to_file_descriptor(const char* sourceBuffer,
         }
 
         bytesWrittenTotal += (size_t) bytesWritten;
-        sourceBuffer += bytesWritten;
-        sourceBufferSize -= bytesWritten;
+        source += bytesWritten;
     }
 
     return bytesWrittenTotal;

--- a/swimps-log/source/swimps-log.cpp
+++ b/swimps-log/source/swimps-log.cpp
@@ -71,7 +71,8 @@ size_t swimps::log::write_to_log(
         break;
     }
 
-    return swimps::io::write_to_file_descriptor(targetBuffer,
-                                           bytesWritten,
-                                           targetFileDescriptor);
+    return swimps::io::write_to_file_descriptor(
+        { targetBuffer, bytesWritten },
+        targetFileDescriptor
+    );
 }

--- a/swimps-test/unit/swimps-io-unit-test/source/swimps-write-to-file-descriptor-test.cpp
+++ b/swimps-test/unit/swimps-io-unit-test/source/swimps-write-to-file-descriptor-test.cpp
@@ -16,7 +16,6 @@ SCENARIO("swimps::io::write_to_file_descriptor", "[swimps-io]") {
         WHEN("The data is written to the file.") {
             const auto bytesWritten = swimps::io::write_to_file_descriptor(
                 sourceBuffer,
-                sizeof sourceBuffer,
                 targetFileDescriptor
             );
 

--- a/swimps-test/unit/swimps-trace-file-unit-test/source/swimps-trace-file-backtrace-test.cpp
+++ b/swimps-test/unit/swimps-trace-file-unit-test/source/swimps-trace-file-backtrace-test.cpp
@@ -62,8 +62,7 @@ SCENARIO("swimps::trace::file::read_backtrace", "[swimps-trace-file]") {
 
         WHEN("A valid backtrace is written to it.") {
             REQUIRE(swimps::io::write_to_file_descriptor(
-                data.data(),
-                data.size(),
+                { data.data(), data.size() },
                 targetFileDescriptor
             ) == data.size());
 


### PR DESCRIPTION
I also added an overload to make writing integral types easier whilst I was at it.