### PR TITLE
Fix bug where log messages got formatted incorrectly.

### DIFF
--- a/swimps-log/include/swimps-log.h
+++ b/swimps-log/include/swimps-log.h
@@ -96,4 +96,20 @@ namespace swimps::log {
             { targetBuffer, bytesWritten }
         );
     }
+
+    //!
+    //! \brief  Formats a message ready for logging.
+    //!
+    //! \param[in]   logLevel  The level to log at.
+    //! \param[in]   message   The message to format.
+    //! \param[out]  target    Where to write the formatted message.
+    //!
+    //! \returns  The number of bytes written to the target.
+    //!
+    //! \note  You do *not* need to call this before logging a message, that is done automatically.
+    //!
+    size_t format_message(
+        const swimps::log::LogLevel logLevel,
+        swimps::container::Span<const char> message,
+        swimps::container::Span<char> target);
 }

--- a/swimps-log/source/swimps-log.cpp
+++ b/swimps-log/source/swimps-log.cpp
@@ -4,7 +4,7 @@
 
 #include <unistd.h>
 
-size_t swimps_format_log_message(
+size_t swimps::log::format_message(
     const swimps::log::LogLevel logLevel,
     swimps::container::Span<const char> message,
     swimps::container::Span<char> target) {
@@ -23,27 +23,35 @@ size_t swimps_format_log_message(
 
     assert(logLevelString != nullptr);
 
-    size_t bytesWritten = swimps::io::write_to_buffer(
+    size_t totalBytesWritten = 0;
+    size_t newBytesWritten = 0;
+
+    newBytesWritten = swimps::io::write_to_buffer(
         { *logLevelString, sizeof(*logLevelString) - 1 },
         target
     );
 
-    target += bytesWritten;
+    totalBytesWritten += newBytesWritten;
+    target += newBytesWritten;
 
-    bytesWritten += swimps::io::write_to_buffer(
+    newBytesWritten = swimps::io::write_to_buffer(
         message,
         target
     );
 
-    target += bytesWritten;
+    totalBytesWritten += newBytesWritten;
+    target += newBytesWritten;
 
     const char newLine[] = { '\n' };
-    bytesWritten += swimps::io::write_to_buffer(
+    newBytesWritten = swimps::io::write_to_buffer(
         newLine,
         target
     );
 
-    return bytesWritten;
+    totalBytesWritten += newBytesWritten;
+    target += newBytesWritten;
+
+    return totalBytesWritten;
 }
 
 size_t swimps::log::write_to_log(
@@ -52,7 +60,7 @@ size_t swimps::log::write_to_log(
 
     char targetBuffer[2048] = { 0 };
 
-    const size_t bytesWritten = swimps_format_log_message(
+    const size_t bytesWritten = swimps::log::format_message(
         logLevel,
         message,
         targetBuffer

--- a/swimps-test/unit/CMakeLists.txt
+++ b/swimps-test/unit/CMakeLists.txt
@@ -19,11 +19,12 @@ add_executable(
     swimps-io-unit-test/source/swimps-read-from-file-descriptor.cpp
     swimps-io-unit-test/source/swimps-format-string-test.cpp
     swimps-io-unit-test/source/swimps-format-string-valist-test.cpp
+    swimps-log-unit-test/source/swimps-format-log-message-test.cpp
     swimps-trace-file-unit-test/source/swimps-trace-file-backtrace-test.cpp
 )
 
 target_include_directories(swimps-unit-test PUBLIC include)
-target_link_libraries(swimps-unit-test swimps-io swimps-container swimps-trace-file Catch2::Catch2)
+target_link_libraries(swimps-unit-test swimps-io swimps-log swimps-container swimps-trace-file Catch2::Catch2)
 
 add_test(NAME swimps-unit-test
          COMMAND $<TARGET_FILE:swimps-unit-test>)

--- a/swimps-test/unit/swimps-log-unit-test/source/swimps-format-log-message-test.cpp
+++ b/swimps-test/unit/swimps-log-unit-test/source/swimps-format-log-message-test.cpp
@@ -1,0 +1,28 @@
+#include "swimps-test.h"
+#include "swimps-log.h"
+
+#include <cstring>
+
+SCENARIO("swimps::log::format_message", "[swimps-log]") {
+    GIVEN("A simple message and a zero-initialised target buffer with plenty of extra room.") {
+        char targetBuffer[2048] =  { };
+        const char message[] = "This is a simple message.";
+
+        WHEN("It is formatted.") {
+
+            const auto bytesWritten = swimps::log::format_message(
+                swimps::log::LogLevel::Debug,
+                { message, sizeof message - 1 /* remove null terminator */ },
+                targetBuffer
+            );
+
+            THEN("The number of bytes written matches the amount of formatted characters.") {
+                REQUIRE(bytesWritten != 0);
+
+                // This is safe since the target buffer is zero-initialised, effectively making it null-terminated.
+                REQUIRE(targetBuffer[bytesWritten] == '\0');
+                REQUIRE(targetBuffer[bytesWritten - 1] != '\0');
+            }
+        }
+    }
+}


### PR DESCRIPTION
This manifested in newlines being missed at the end of messages.

The program was that the target span was being incremented by the
total number of bytes written, rather than the new bytes written.