### PR TITLE
Exclude swimps-profile-child from coverage as it yields incorrect data.

### DIFF
--- a/swimps-profile/source/swimps-profile-child.cpp
+++ b/swimps-profile/source/swimps-profile-child.cpp
@@ -16,6 +16,7 @@
 extern char** environ;
 
 swimps::error::ErrorCode swimps::profile::child(const swimps::option::Options& options) {
+    // LCOV_EXCL_START
     if (options.targetProgram.empty()) {
         swimps::log::write_to_log(
             swimps::log::LogLevel::Fatal,
@@ -173,4 +174,5 @@ swimps::error::ErrorCode swimps::profile::child(const swimps::option::Options& o
     }
 
     return swimps::error::ErrorCode::ExecveFailed;
+    // LCOV_EXCL_STOP
 }


### PR DESCRIPTION
It's been problematic since finding executables via PATH was added.